### PR TITLE
[XXXX] Fix auto-mock Function injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-## 1.0.1 (July 22, 2025)
+## 1.0.3 (July 23, 2025)
+ - Mock Global Function to reflect on auto mock
+ - Fix last CHANGELOG.md entry to reflect the correct date (metalanguage)
+
+
+## 1.0.2 (July 22, 2025)
  - Fix type declaration issues not being included in dist
  - Add `cpy-cli` to copy type declarations to the `dist` folder
  - Update `yarn build` script to include copying type declarations

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-extended-fn-mocks",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Extends the Jest Fn mock methods",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",

--- a/src/setup-extensions.test.ts
+++ b/src/setup-extensions.test.ts
@@ -16,10 +16,15 @@ describe('setup-extensions', () => {
     ${'mockImplementationForTestcase'} | ${mockImplForTestcaseModule.mockImplementationForTestcase}
     ${'mockReturnForDescribe'}         | ${mockReturnForDescModule.mockReturnForDescribe}
     ${'mockReturnForTestcase'}         | ${mockReturnForTestcaseModule.mockReturnForTestcase}
-  `('sets $methodName on jest.fn prototype', ({ methodName, fn }) => {
-    require('./setup-extensions')
-    expect(jest.fn()[c<keyof jest.Mock>(methodName)]).toBe(fn)
-  })
+  `(
+    'sets $methodName on jest.fn and Function prototype',
+    ({ methodName, fn }) => {
+      require('./setup-extensions')
+      const jsFn = () => null
+      expect(jest.fn()[c<keyof jest.Mock>(methodName)]).toBe(fn)
+      expect(c<jest.Mock>(jsFn)[c<keyof jest.Mock>(methodName)]).toBe(fn)
+    },
+  )
   it.each`
     setupName                          | setupFn
     ${'mockImplementationForTestcase'} | ${mockImplForTestcaseModule.setup}

--- a/src/setup-extensions.ts
+++ b/src/setup-extensions.ts
@@ -11,12 +11,15 @@ import {
 
 const FnConstructor = jest.fn().constructor
 
-FnConstructor.prototype.mockReturnForDescribe = mockReturnForDescribe
-FnConstructor.prototype.mockImplementationForDescribe =
-  mockImplementationForDescribe
-FnConstructor.prototype.mockReturnForTestcase = mockReturnForTestcase
-FnConstructor.prototype.mockImplementationForTestcase =
-  mockImplementationForTestcase
+;[
+  mockReturnForDescribe,
+  mockImplementationForDescribe,
+  mockReturnForTestcase,
+  mockImplementationForTestcase,
+].forEach(fn => {
+  FnConstructor.prototype[fn.name] = fn
+  globalThis.Function.constructor.prototype[fn.name] = fn
+})
 
 mockImplementationForTestcaseSetup()
 mockReturnForTestcaseSetup()


### PR DESCRIPTION
## Request

// no request link

## Summary

### Details

Jest does no work with the `Jest.fn` as the constructor function when auto-mocking files to keep the properties of the function:

https://github.com/jestjs/jest/blob/main/packages/jest-mock/src/index.ts#L918

In order to keep injecting the new mock helpers, I'm adding these prototypes on the global Function.

### Changes

 - `setup-extensioins.ts`:
  - I'm iterating through the mocks to define it as prototypes of functions
  - I'm creating the prototype on the global Function
- `Change LOG`
  - Fixed the last version for 1.0.2
